### PR TITLE
[Draft] OAuth Auth Support, Full Blob Download Rough Draft (rust)

### DIFF
--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -26,7 +26,7 @@ mod models;
 mod options;
 mod pageable;
 mod pipeline;
-mod policies;
+pub mod policies;
 mod request;
 mod response;
 mod seekable_stream;

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -1,3 +1,4 @@
+use crate::policies::BearerTokenCredentialPolicy;
 use crate::policies::TransportPolicy;
 use crate::policies::{CustomHeadersPolicy, Policy, TelemetryPolicy};
 use crate::{ClientOptions, Context, Request, Response};

--- a/sdk/core/src/policies/mod.rs
+++ b/sdk/core/src/policies/mod.rs
@@ -1,11 +1,13 @@
 mod custom_headers_policy;
 mod retry_policies;
+mod storage_bearer_token;
 mod telemetry_policy;
 mod timeout_policy;
 mod transport;
 
 pub use custom_headers_policy::{CustomHeaders, CustomHeadersPolicy};
 pub use retry_policies::*;
+pub use storage_bearer_token::*;
 pub use telemetry_policy::*;
 pub use timeout_policy::*;
 pub use transport::*;

--- a/sdk/core/src/policies/storage_bearer_token.rs
+++ b/sdk/core/src/policies/storage_bearer_token.rs
@@ -10,15 +10,11 @@ use tracing::debug;
 #[derive(Debug, Clone)]
 pub struct BearerTokenCredentialPolicy {
     credential: Arc<dyn TokenCredential>,
-    pipeline: Pipeline,
 }
 
 impl BearerTokenCredentialPolicy {
-    pub fn new(credential: Arc<dyn TokenCredential>, pipeline: Pipeline) -> Self {
-        Self {
-            credential,
-            pipeline,
-        }
+    pub fn new(credential: Arc<dyn TokenCredential>) -> Self {
+        Self { credential }
     }
 }
 
@@ -37,12 +33,9 @@ impl Policy for BearerTokenCredentialPolicy {
             .await?;
         let token = access_token.token.secret();
 
-        // Need to hardcode a version because it's failing
-        request.insert_header("x-ms-version", "2023-11-03");
-
         request.insert_header("authorization", format!("Bearer {token}"));
         debug!("the following request will be passed to the transport policy: {request:#?}");
 
-        self.pipeline.send(ctx, request).await
+        next[0].send(ctx, request, &next[1..]).await
     }
 }

--- a/sdk/core/src/policies/storage_bearer_token.rs
+++ b/sdk/core/src/policies/storage_bearer_token.rs
@@ -33,6 +33,7 @@ impl Policy for BearerTokenCredentialPolicy {
             .await?;
         let token = access_token.token.secret();
         request.insert_header("authorization", format!("Bearer {token}"));
+        debug!("the following request will be passed to the transport policy: {request:#?}");
 
         next[0].send(ctx, request, &next[1..]).await
     }

--- a/sdk/core/src/policies/storage_bearer_token.rs
+++ b/sdk/core/src/policies/storage_bearer_token.rs
@@ -1,0 +1,39 @@
+use crate::{
+    auth::TokenCredential,
+    policies::{Policy, PolicyResult},
+    Context, Request,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tracing::debug;
+
+#[derive(Debug, Clone)]
+pub struct BearerTokenCredentialPolicy {
+    credential: Arc<dyn TokenCredential>,
+}
+
+impl BearerTokenCredentialPolicy {
+    pub fn new(credential: Arc<dyn TokenCredential>) -> Self {
+        Self { credential }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl Policy for BearerTokenCredentialPolicy {
+    async fn send(
+        &self,
+        ctx: &Context,
+        request: &mut Request,
+        next: &[Arc<dyn Policy>],
+    ) -> PolicyResult {
+        let access_token = self
+            .credential
+            .get_token(&["https://storage.azure.com/.default"])
+            .await?;
+        let token = access_token.token.secret();
+        request.insert_header("authorization", format!("Bearer {token}"));
+
+        next[0].send(ctx, request, &next[1..]).await
+    }
+}

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -17,5 +17,6 @@ edition.workspace = true
 [dependencies]
 azure_core = { workspace = true }
 azure_identity = { workspace = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -16,5 +16,6 @@ edition.workspace = true
 
 [dependencies]
 azure_core = { workspace = true }
+azure_identity = { workspace = true }
 
 [lints]

--- a/sdk/storage_blobs/src/blob_client.rs
+++ b/sdk/storage_blobs/src/blob_client.rs
@@ -26,7 +26,10 @@ impl BlobClient {
         // In this case, we determine it's Oauth
         println!("Auth type chosen, Oauth, {}", credential);
         let credential = create_credential().expect("Failed for some reason?");
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(credential.clone());
+        let oauth_token_policy = BearerTokenCredentialPolicy::new(
+            credential.clone(),
+            &["https://storage.azure.com/.default"],
+        );
 
         // Build the runner pipeline
         let runner_pipeline = Pipeline::new(

--- a/sdk/storage_blobs/src/blob_client.rs
+++ b/sdk/storage_blobs/src/blob_client.rs
@@ -1,66 +1,93 @@
 use azure_core::{
-    auth::TokenCredential, policies::BearerTokenCredentialPolicy, Context, Method, Policy, Request,
-    Url,
+    auth::TokenCredential, policies::BearerTokenCredentialPolicy, ClientOptions, Context, Error,
+    Method, Pipeline, Policy, Request, Response, Url,
 };
 use azure_identity::create_credential;
 use std::sync::Arc;
 
-pub struct BlobClient<'a> {
-    account_name: &'a str,
+pub struct BlobClient {
+    account_name: String,
     credential: Arc<dyn TokenCredential>,
-    container_name: &'a str,
-    blob_name: &'a str,
+    container_name: String,
+    blob_name: String,
     pipeline: BearerTokenCredentialPolicy,
 }
 
-impl BlobClient<'_> {
+impl BlobClient {
     pub fn new(
-        account_name: &str,
-        credential: &str,
-        container_name: &str,
-        blob_name: &str,
+        account_name: String,
+        credential: String,
+        container_name: String,
+        blob_name: String,
     ) -> Self {
         // Create Respective Authentication Pipeline
 
         // In this case, we determine it's Oauth
         println!("Auth type chosen, Oauth, {}", credential);
         let credential = create_credential().expect("Failed for some reason?");
+        let runner_pipeline = Pipeline::new(
+            option_env!("CARGO_PKG_NAME"),
+            option_env!("CARGO_PKG_VERSION"),
+            ClientOptions::default(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let oauth_token_pipeline =
+            BearerTokenCredentialPolicy::new(credential.clone(), runner_pipeline);
         Self {
             account_name: account_name,
             credential: credential.clone(), // Unsure if clone is the correct move here
             container_name: container_name,
             blob_name: blob_name,
-            pipeline: BearerTokenCredentialPolicy::new(credential),
+            pipeline: oauth_token_pipeline,
         }
     }
 
-    pub async fn download_blob(&self) {
-        // Build the things needed for the downlaod request
+    pub async fn download_blob(&self) -> String {
+        // Build the things needed for the download request
 
         // Would probably have a sophisticated blob url builder
         let blob_url = "https://".to_owned()
-            + self.account_name
+            + &(self.account_name)
             + ".blob.core.windows.net/"
-            + self.container_name
+            + &(self.container_name)
             + "/"
-            + self.blob_name;
+            + &(self.blob_name);
         let blob_url = Url::parse(&blob_url).expect("Failed to parse URL for some reason");
 
         // Build the download request itself
         let mut request = Request::new(blob_url, Method::Get);
 
-        // Cast our custom policy to regular policy?
-        let copied_policy = vec![Arc::new(self.pipeline.clone()) as Arc<dyn Policy>];
-
         // Send the request
         let response = self
             .pipeline
-            .send(&(Context::new()), &mut request, &copied_policy)
+            .send(&(Context::new()), &mut request, &[])
             .await;
         println!("Response headers: {:?}", response);
 
         // Look at request body
         let response_body = response.unwrap().into_body().collect_string().await;
         println!("Response body: {:?}", response_body);
+
+        response_body.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::BlobClient;
+
+    #[tokio::test]
+    async fn test_blob_client() {
+        // Create a Blob Client
+        let my_blob_client = BlobClient::new(
+            "vincenttranstock".to_string(),
+            "throwaway".to_string(),
+            "acontainer108f32e8".to_string(),
+            "hello.txt".to_string(),
+        );
+
+        // Assert equality
+        assert_eq!(my_blob_client.download_blob().await, "rustaceans")
     }
 }

--- a/sdk/storage_blobs/src/blob_container_client.rs
+++ b/sdk/storage_blobs/src/blob_container_client.rs
@@ -23,9 +23,9 @@ impl<T: AccountStructure> BlobContainerClient<T> {
         &self.endpoint
     }
 
-    pub fn get_blob_client(&self, blob_name: &str) -> BlobClient<Unset, Unset> {
-        todo!()
-    }
+    // pub fn get_blob_client(&self, blob_name: &str) -> BlobClient<Unset, Unset> {
+    //     todo!()
+    // }
 
     pub fn get_blobs(&self) -> Pageable<BlobItem, HttpError> {
         todo!()


### PR DESCRIPTION
This PR is a very very primitive approach at the following functionality:

- Working OAuth support through StorageBearerToken (very primitive, no rehydrate, need to `az login` yourself if not working)
- Barebones Blob Client
- Download Blob (no knobs, no partial downloads)
- Get Blob Properties (no knobs)

I know there are a lot of patterns and non-idiomatic things happening here, my current goal is to flesh it out in a working state and then implement logical modules afterwards (auth, pipeline, models, etc.)

Any feedback would be greatly appreciated for ways to improve the current implementation (including structural changes / library layout, types)